### PR TITLE
docs: remove duplicate `&`

### DIFF
--- a/topics/README.md
+++ b/topics/README.md
@@ -110,7 +110,7 @@ Find more information about this session on the [topic page](Week4_Security/READ
 </td>
 <td>
 
-## Data && Analytics
+## Data & Analytics
 
 Topic Owner: [Vitaliy Rudnytskiy](https://github.com/Sygyzmundovych)
 

--- a/topics/Week5_Data/README.md
+++ b/topics/Week5_Data/README.md
@@ -1,4 +1,4 @@
-# Data && Analytics
+# Data & Analytics
 
 This topic content is for Devtoberfest Week 5: November 1 → 5, 2021.
 


### PR DESCRIPTION
I'm not completly sure about this but I think the `&&` is not correct here and only should be `&`